### PR TITLE
Add optional typing for opts and a new everyPredicate helper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
 		sourceType: 'module',
 	},
 	rules:  {
+		"@typescript-eslint/no-explicit-any": "off"
 	}
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,27 +4,40 @@ import { METHODS } from 'http';
 // Utilities
 import { MicriHandler, IncomingMessage, ServerResponse } from './types';
 
-type Predicate = (req: IncomingMessage, res: ServerResponse, opts?: object) => boolean;
+type Predicate<OptsType> = (req: IncomingMessage, res: ServerResponse, opts?: OptsType) => boolean;
+type OnFunction<OptsType> = (
+	pred: Predicate<OptsType>,
+	hndl: MicriHandler<OptsType>
+) => [Predicate<OptsType>, MicriHandler<OptsType>];
 
-const router = (...rest: [Predicate, MicriHandler][]): MicriHandler => (
+const router = <OptsType = any>(...rest: [Predicate<OptsType>, MicriHandler<OptsType>][]): MicriHandler<OptsType> => (
 	req: IncomingMessage,
 	res: ServerResponse,
-	opts?: object
+	opts?: OptsType
 ): any =>
 	(rest.find((route) => route[0](req, res, opts)) || [
 		null,
-		() => {
+		(): void => {
 			throw Error('No matching route was found');
 		},
 	])[1](req, res, opts);
 
+const onInit: { [index: string]: OnFunction<any> } = {};
 const on = METHODS.map((method) => [
 	method.toLowerCase(),
-	(pred: Predicate, fn: MicriHandler): [Predicate, MicriHandler] => [
-		(req, res, opts) => req.method === method && pred(req, res, opts),
+	(pred: Predicate<any>, fn: MicriHandler<any>): [Predicate<any>, MicriHandler<any>] => [
+		(req, res, opts): boolean => req.method === method && pred(req, res, opts),
 		fn,
 	],
-]).reduce((acc: any, curr: any) => ({ ...acc, ...{ [curr[0]]: curr[1] } }), {});
-const otherwise = (fn: MicriHandler): [Predicate, MicriHandler] => [() => true, fn];
+]).reduce((acc: { [index: string]: OnFunction<any> }, curr: any) => ({ ...acc, ...{ [curr[0]]: curr[1] } }), onInit);
+const otherwise = <OptsType = any>(fn: MicriHandler<OptsType>): [Predicate<OptsType>, MicriHandler<OptsType>] => [
+	(): boolean => true,
+	fn,
+];
 
-export { Predicate, router, on, otherwise };
+function everyPredicate<OptsType = any>(...t: Predicate<OptsType>[]): Predicate<OptsType> {
+	return (req: IncomingMessage, res: ServerResponse, opts?: OptsType): boolean =>
+		t.every((f): boolean => f(req, res, opts));
+}
+
+export { Predicate, router, on, otherwise, everyPredicate };

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -153,7 +153,7 @@ export const sendError = (req: IncomingMessage, res: ServerResponse, errorObj: M
 	send(res, statusCode, body);
 };
 
-export function run(req: IncomingMessage, res: ServerResponse, fn: MicriHandler) {
+export function run<OptsType = any>(req: IncomingMessage, res: ServerResponse, fn: MicriHandler<OptsType>) {
 	return new Promise((resolve) => resolve(fn(req, res)))
 		.then((val) => {
 			if (val === null) {
@@ -171,5 +171,5 @@ export function run(req: IncomingMessage, res: ServerResponse, fn: MicriHandler)
 		.catch((err) => sendError(req, res, err));
 }
 
-export const serve = (fn: MicriHandler): Server =>
-	createServer((req: IncomingMessage, res: ServerResponse) => run(req, res, fn));
+export const serve = <OptsType = any>(fn: MicriHandler<OptsType>): Server =>
+	createServer((req: IncomingMessage, res: ServerResponse) => run<OptsType>(req, res, fn));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // Native
 import { IncomingMessage, ServerResponse, IncomingHttpHeaders, Server } from 'http';
 
-export type MicriHandler = (req: IncomingMessage, res: ServerResponse, opts?: object) => any;
+export type MicriHandler<OptsType = any> = (req: IncomingMessage, res: ServerResponse, opts?: OptsType) => any;
 export { IncomingMessage, ServerResponse, IncomingHttpHeaders, Server };
 export interface IncomingOpts {
 	limit?: string | number;


### PR DESCRIPTION
- Add `OptsType` as a generic type for `opts` so the typing can
   be tracked better
- Add `everyPredicate()` helper function to allow combining
   common predicate functions more easily

Fixes #17