### PR TITLE
Use handler-agent for better with-worker performance

### DIFF
--- a/examples/with-worker/src/prime.ts
+++ b/examples/with-worker/src/prime.ts
@@ -2,6 +2,8 @@ export default function fn() {
 	const limit = 3e5;
 	let r;
 
+	console.log('This is going to take a while...');
+
 	for (let n = 2; n <= limit; n++) {
 		let isPrime = true;
 		for(let factor = 2; factor < n; factor++) {

--- a/lib/worker-wrapper.js
+++ b/lib/worker-wrapper.js
@@ -1,5 +1,6 @@
-const { serve } = require('./index');
+const handlerAgent = require('handler-agent');
 const { request } = require('http');
+const { run } = require('./index');
 const { parentPort, workerData } = require('worker_threads');
 
 module.exports = async function wrap(fn) {
@@ -8,45 +9,43 @@ module.exports = async function wrap(fn) {
 			parentPort.on('message', (body) => resolve(body));
 		});
 
-		const server = serve((req, res) => fn(req, res, workerData.opts));
-		server.listen(() => {
-			const port = server.address().port;
-			const intReq = request(
-				`http://127.0.0.1${workerData.req.url}`,
-				{
-					hostname: '127.0.0.1',
-					port,
-					method: workerData.req.method,
-					headers: {
-						...workerData.req.headers,
-						'Content-Length': buf.length,
-					},
+		const agent = handlerAgent((req, res) => run(req, res, (req, res) => fn(req, res, workerData.opts)));
+		const intReq = request(
+			`http://127.0.0.1${workerData.req.url}`,
+			{
+				agent,
+				hostname: '127.0.0.1',
+				port: 1337,
+				method: workerData.req.method,
+				headers: {
+					...workerData.req.headers,
+					'Content-Length': buf.length,
 				},
-				(res) => {
-					const head = {
-						statusCode: res.statusCode || 200,
-						statusMessage: res.statusMessage,
-						headers: res.headers,
-					};
+			},
+			(res) => {
+				const head = {
+					statusCode: res.statusCode || 200,
+					statusMessage: res.statusMessage,
+					headers: res.headers,
+				};
 
-					parentPort.postMessage(head);
+				parentPort.postMessage(head);
 
-					res.on('data', (chunk) => {
-						parentPort.postMessage(chunk);
-					});
-					res.on('end', () => {
-						process.exit(0);
-					});
-				}
-			);
-			intReq.on('error', (err) => {
-				console.error(err);
-				process.exit(1);
-			});
-
-			intReq.write(Buffer.from(buf));
-			intReq.end();
+				res.on('data', (chunk) => {
+					parentPort.postMessage(chunk);
+				});
+				res.on('end', () => {
+					process.exit(0);
+				});
+			}
+		);
+		intReq.on('error', (err) => {
+			console.error(err);
+			process.exit(1);
 		});
+
+		intReq.write(Buffer.from(buf));
+		intReq.end();
 	} catch (err) {
 		console.error(err);
 		process.exit(1);

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   },
   "git": {
     "pre-commit": "lint-staged"
+  },
+  "dependencies": {
+    "handler-agent": "0.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,6 +1648,11 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+handler-agent@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/handler-agent/-/handler-agent-0.1.1.tgz#f720eb3150cb62880ebf336274e5202a77a78768"
+  integrity sha512-RdMTjkqRquAaH8bYpQ5ImBrzgoJPf8OAvtPeo+Z5hngSJNaXwCmB6EhIWC+rFsHdCXytKjKny8p3bnCWmux65Q==
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"


### PR DESCRIPTION
Currently `with-worker` causes `worker-wrapper` to create temp
HTTP server which is used to serve the request over TCP. This
naturally causes some unnecessary latency as the data must go thru
the kernel in order to get it back to the handler. While
`handler-agent` still creates a temporary server it uses a clever
way to pipe the request directly to the handler thru Node.js's
internals, avoiding all the syscalls and random latency penalties.